### PR TITLE
feat: Manager and Coaches didn't see the same infos on statistics page

### DIFF
--- a/angular-frontend/src/app/pages/statistics/statistics.component.html
+++ b/angular-frontend/src/app/pages/statistics/statistics.component.html
@@ -3,7 +3,7 @@
     <hr>
 </div>
 
-<div class="columns is-multiline">
+<div *ngIf="this._auth.isManager()" class="columns is-multiline">
     <div class="column is-6">
         <div #containerRef class="card is-flex is-justify-content-center">
             <ngx-charts-number-card

--- a/angular-frontend/src/app/pages/statistics/statistics.component.ts
+++ b/angular-frontend/src/app/pages/statistics/statistics.component.ts
@@ -7,6 +7,7 @@ import { Component } from '@angular/core';
 import { Employee, EmployeesService } from 'src/app/service/employees/employees.service';
 import { NgxChartsModule } from '@swimlane/ngx-charts';
 import { Customer } from 'src/app/service/customers/customers.service';
+import { AuthService } from 'src/app/service/auth/auth.service';
 
 @Component({
   selector: 'app-statistics',
@@ -23,6 +24,7 @@ export class StatisticsPageComponent {
     employeesCustomers:Customer[] = [];
     encounters: Encounter[] = [];
     payments:PaymentHistory[] = [];
+    me?: Employee;
 
     customerResults : any = {};
     encounterResults : any = {};
@@ -45,15 +47,18 @@ export class StatisticsPageComponent {
         private customersService: CustomersService,
         private paymentHistoryService: PaymentHistoryService,
         private tipsService: TipsService,
-        private eventsService: EventsService
+        private eventsService: EventsService,
+        public _auth: AuthService
     ) { }
 
     async ngOnInit() {
-        this.initTips();
-        this.initEvents();
-        await this.initPayments();
-        await this.initEncounters();
-        await this.initCustomers();
+        if (this._auth.isManager()) {
+            this.initTips();
+            this.initEvents();
+            await this.initPayments();
+            await this.initEncounters();
+            await this.initCustomers();
+        }
         await this.initEmployees();
     }
 
@@ -75,8 +80,16 @@ export class StatisticsPageComponent {
 
     async initEmployees() {
 
-        this.employees = await this.employeesService.getEmployees();
-        this.coaches = this.employees.filter(employee => employee.work === 'Coach');
+        if (this._auth.isManager()) {
+            this.employees = await this.employeesService.getEmployees();
+            this.coaches = this.employees.filter(employee => employee.work === 'Coach');
+        } else {
+            this.me = await this.employeesService.getMe();
+            if (this.me !== undefined) {
+                this.employees = [this.me];
+                this.coaches = [this.me];
+            }
+        }
         this.nbEmployees[0] = this.employees;
         this.nbCoaches[0] = this.coaches;
 


### PR DESCRIPTION
Now, on the statistics page, Manager can see all company's stats and coaches only their data.

Managers:
![image](https://github.com/user-attachments/assets/d8ffbf11-7257-42d4-8f9b-8021ed80d653)

Coaches:
![image](https://github.com/user-attachments/assets/fdbbf7e0-395c-4e27-8a75-52329055a76b)
