### PR TITLE
feat(login page): add a pop up in case of wrong login or password

### DIFF
--- a/angular-frontend/src/app/pages/login/login.component.html
+++ b/angular-frontend/src/app/pages/login/login.component.html
@@ -1,6 +1,11 @@
 <div class="is-flex is-justify-content-center is-align-items-center container-login">
     <div class="has-text-centered m-4">
         <p class="title is-1 mb-5">Welcome</p>
+
+        <div *ngIf="wrongPassword">
+            <p class="subtitle is-4 has-text-danger mb-3">Wrong login or password !</p>
+        </div>
+
         <form>
             <input class="input is-large mb-2" type="text" [(ngModel)]="this.Email" id="email" name="email" placeholder="Email" required>
 

--- a/angular-frontend/src/app/pages/login/login.component.ts
+++ b/angular-frontend/src/app/pages/login/login.component.ts
@@ -9,11 +9,14 @@ import { AuthService } from 'src/app/service/auth/auth.service';
 export class LoginComponent {
     Email = '';
     Password = '';
+    wrongPassword = false;
 
     constructor (private authService: AuthService) {}
 
     loginClick () {
         this.authService.login(this.Email, this.Password);
+        if (this.authService.isLogged() == false)
+          this.wrongPassword = true;
         this.Password = '';
     }
 }


### PR DESCRIPTION
I've add a pop up in case of wrong login or password in the login page.

![image](https://github.com/user-attachments/assets/56da358c-e8f3-4f3c-814a-fbb758974577)
